### PR TITLE
Refactor Docker workflow and update README for breaking changes

### DIFF
--- a/.github/workflows/srsrelease-dockerhub.yml
+++ b/.github/workflows/srsrelease-dockerhub.yml
@@ -50,16 +50,13 @@ jobs:
           fi
           echo "tag=$TAG" >> $GITHUB_OUTPUT
 
-      - name: Download SRS release zip
+      - name: Download SRS release binary
         run: |
-          ASSET_URL=$(curl -s https://api.github.com/repos/ciribob/DCS-SimpleRadioStandalone/releases/tags/${{ steps.get_srs_tag.outputs.tag }} | jq -r '.assets[] | select(.name | test("^DCS-SimpleRadioStandalone-.*\\.zip$")) | .browser_download_url')
-          if [ -z "$ASSET_URL" ]; then
-            echo "Could not find DCS-SimpleRadioStandalone-<version>.zip asset for tag ${{ steps.get_srs_tag.outputs.tag }}"
-            exit 1
-          fi
-          curl -L "$ASSET_URL" -o DCS-SimpleRadioStandalone.zip
+          TAG="${{ steps.get_srs_tag.outputs.tag }}"
+          URL="https://github.com/ciribob/DCS-SimpleRadioStandalone/releases/download/${TAG}/SRS-Server-Commandline"
           mkdir -p install-build/ServerCommandLine-Linux
-          unzip -j DCS-SimpleRadioStandalone.zip 'ServerCommandLine-Linux/SRS-Server-Commandline' -d install-build/ServerCommandLine-Linux/SRS-Server-Commandline
+          curl -L "$URL" -o install-build/ServerCommandLine-Linux/SRS-Server-Commandline
+          chmod +x install-build/ServerCommandLine-Linux/SRS-Server-Commandline
 
       - name: Set Docker tags
         id: set_tags

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,16 @@
 # Use Ubuntu 24.04 LTS as the base image
-FROM ubuntu:24.04
+FROM ubuntu/dotnet-deps:8.0
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Update package lists and install required runtime dependencies
-# --no-install-recommends: Only install essential packages to keep image size small
-# The packages installed are:
-#   - libstdc++6: C++ standard library (required for C++ applications)
-#   - libgcc-s1: GCC runtime library (required for compiled applications)
-#   - libicu74: Unicode support library (for internationalization)
-#   - ca-certificates: SSL/TLS certificate authorities (for secure connections)
-# Clean up package cache to reduce image size
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        libstdc++6 \
-        libgcc-s1 \
-        libicu74 \
-        ca-certificates && \
-    apt-get clean && \ 
-    rm -rf /var/lib/apt/lists/*
-
 # Set the working directory inside the container
 # All subsequent commands will be executed from this directory
-WORKDIR /opt/srs
+WORKDIR /app
 
 # Copy the SRS server Linux CLI executable and startup script from the build context
 # The source binary path was choosed to be future proof if the binary build become part of the same pipeline
 # In order to build the container image properly, the docker build or pipeline must run in the context of the root of the repository
-COPY ./install-build/ServerCommandLine-Linux/SRS-Server-Commandline .
-
-# Make the copied files executable
-# This is necessary because file permissions may not be preserved during COPY
-RUN chmod +x SRS-Server-Commandline
+COPY --chown=101:101 --chmod=+x ./install-build/ServerCommandLine-Linux/SRS-Server-Commandline .
 
 # Define the default command to run when the container starts
 # The entrypoint script will handle the application startup

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ Built images are published to Docker Hub for easy deployment and updates.
 
 ---
 
+## BREAKING CHANGE ON 2025-06-19 (still 2.2.0.4)
+* The Docker image base was migrated from `ubuntu:24.04` to `ubuntu/dotnet-deps:8.0` to provide a lighter, .NET-ready environment for the SRS server. This change improves build speed and reduces image size, while ensuring compatibility with the .NET 8 runtime required by the latest SRS Linux CLI binaries.
+* The work directory changed from /opt/srs to /app toi follow common practice, you may have to change the way you initiate the container to reflect this path change.
+
+---
+
 ## Benefits
 
 - **Automated Build Pipeline:**  
@@ -35,8 +41,8 @@ All images are published to:
 - **Tag format:**  
   `srs-<srstag>`
 - **Example:**  
-  `flisher/dcs-srs-server:srs-2.2.0.2`  
-  This image is created by using the pre-compiled binary  included in the SRS release [2.2.0.2](https://github.com/ciribob/DCS-SimpleRadioStandalone/releases/tag/2.2.0.2).
+  `flisher/dcs-srs-server:srs-2.2.0.4`  
+  This image is created by using the pre-compiled binary  included in the SRS release [2.2.0.4](https://github.com/ciribob/DCS-SimpleRadioStandalone/releases/tag/2.2.0.4).
 
 ### 2. Based on Latest Commit from SRS Master Branch
 
@@ -56,7 +62,7 @@ All images are published to:
 - **Tag format:**  
   `compiled-<srstag>`
 - **Example:**  
-  `flisher/dcs-srs-server:compiled-2.2.0.2`  
+  `flisher/dcs-srs-server:compiled-2.2.0.4`  
   This image is built by compiling the SRS ServerCommandLine Linux binary **in the cloud as part of the workflow**, using the source code from the associated SRS release tag.
 
 ---
@@ -72,13 +78,13 @@ docker pull flisher/dcs-srs-server:latest
 ### Pulling a Released version using a binary compiled from the source linked to that release
 
 ```sh
-docker pull flisher/dcs-srs-server:compiled-2.2.0.2
+docker pull flisher/dcs-srs-server:compiled-2.2.0.4
 ```
 
 ### Pulling a Released version using the official binary
 
 ```sh
-docker pull flisher/dcs-srs-server:srs-2.2.0.2
+docker pull flisher/dcs-srs-server:srs-2.2.0.4
 ```
 These should ideally be launhed from as a docker compose.  
 This project isn't intented to provide all instruction, but simply provide Docker Images to suit various tastes.
@@ -98,3 +104,11 @@ This project is **not an official project** of Ciribob, nor is it affiliated wit
 It is a personal effort to support DCS SRS ecosystem by providing automated and traceable Docker images for the Linux CLI version of the SRS server.
 
 This project might be temporary and may cease to exist if an official image is provided as part an tracable pipeline.
+
+---
+
+## BREAKING CHANGE RON 2025-06-19
+* The Docker image base was migrated from `ubuntu:24.04` to `ubuntu/dotnet-deps:8.0` to provide a lighter, .NET-ready environment for the SRS server. This change improves build speed and reduces image size, while ensuring compatibility with the .NET 8 runtime required by the latest SRS Linux CLI binaries.
+* The work directory changed from /opt/srs to /app toi follow common practice, you may have to change the way you initiate the container to reflect this path change.
+
+---


### PR DESCRIPTION
- Changed Docker base image from `ubuntu:24.04` to `ubuntu/dotnet-deps:8.0` for improved build speed and reduced image size.
- Updated working directory from `/opt/srs` to `/app` to follow common practices.
- Modified the download step to fetch the SRS server binary directly.
- Added breaking change notes in README to inform users of necessary adjustments.